### PR TITLE
Tweak comment text if no step input exists

### DIFF
--- a/.github/workflows/pipelines-delegated.yml
+++ b/.github/workflows/pipelines-delegated.yml
@@ -77,7 +77,7 @@ jobs:
           step_name: ${{ matrix.jobs.ChangeType }}
           step_working_directory: ${{ matrix.jobs.WorkingDirectory }}
           step_status: ${{ steps.terragrunt.conclusion == 'success' && 'success' || 'failed' }}
-          step_details: ${{ steps.terragrunt.outputs.formatted_plan_output || steps.terragrunt.outputs.execute_stdout || 'Unable to determine output. Check the logs for more details.' }}
+          step_details: ${{ steps.terragrunt.outputs.formatted_plan_output || steps.terragrunt.outputs.execute_stdout || 'Check the logs for more details.' }}
           step_details_extended: ${{ steps.terragrunt.outputs.execute_stdout }}
           pull_request_number: ${{ steps.bootstrap.outputs.pr_number }}
 

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -105,7 +105,7 @@ jobs:
           step_name: ${{ matrix.jobs.ChangeType }}
           step_working_directory: ${{ matrix.jobs.WorkingDirectory }}
           step_status: ${{ (steps.provision_access_control.conclusion == 'success' || steps.terragrunt.conclusion == 'success' || steps.core_accounts_baselines.conclusion == 'success') && 'success' || 'failed' }}
-          step_details: ${{ steps.terragrunt.outputs.formatted_plan_output || steps.terragrunt.outputs.execute_stdout || 'Unable to determine output. Check the logs for more details.' }}
+          step_details: ${{ steps.terragrunt.outputs.formatted_plan_output || steps.terragrunt.outputs.execute_stdout || 'Check the logs for more details.' }}
           pull_request_number: ${{ steps.bootstrap.outputs.pr_number }}
 
     outputs:
@@ -152,7 +152,7 @@ jobs:
         with:
           step_name: Baseline Child Account ${{ matrix.jobs.Name }}
           step_status: ${{ steps.baseline_child_account.conclusion == 'success' && 'success' || 'failed' }}
-          step_details: ${{ steps.baseline_child_account.outputs.formatted_plan_output || steps.baseline_child_account.outputs.execute_stdout || 'Unable to determine output. Check the logs for more details.' }}
+          step_details: ${{ steps.baseline_child_account.outputs.formatted_plan_output || steps.baseline_child_account.outputs.execute_stdout || 'Check the logs for more details.' }}
           pull_request_number: ${{ needs.pipelines_determine.outputs.pr_number }}
 
   pipelines_setup_delegated_repo:


### PR DESCRIPTION
In some situations we hit the comment code when we have not run the preceding step resulting in e.g. steps.terragrunt not being set. As a short term fix tweak the wording to be more user friendly, longer term identify when this occurs and what comment output we should be using.