### PR TITLE
chore: Bumping `pipelines-cli` to `v0.9.10`

### DIFF
--- a/.github/workflows/pipelines-delegated.yml
+++ b/.github/workflows/pipelines-delegated.yml
@@ -7,7 +7,7 @@ on:
         required: true
 
 env:
-  PIPELINES_CLI_VERSION: v0.9.9
+  PIPELINES_CLI_VERSION: v0.9.10
   PIPELINES_ACTIONS_VERSION: v1.1.3
 
 jobs:

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -11,7 +11,7 @@ on:
         required: false
 
 env:
-  PIPELINES_CLI_VERSION: v0.9.9
+  PIPELINES_CLI_VERSION: v0.9.10
   PIPELINES_ACTIONS_VERSION: v1.1.3
 
 jobs:


### PR DESCRIPTION
Upgrading `pipelines-cli` to `v0.9.10`.

