### PR TITLE
Customization Hooks

### DIFF
--- a/.github/custom_actions/post_baseline_child_account.yml
+++ b/.github/custom_actions/post_baseline_child_account.yml
@@ -13,3 +13,10 @@ inputs:
   job:
     description: "JSON of pipelines orchestrate job"
     required: true
+runs:
+  using: composite
+  steps:
+    - name: Custom Logic Goes Here
+      shell: bash
+      run: |
+        exit 0

--- a/.github/custom_actions/post_baseline_child_account.yml
+++ b/.github/custom_actions/post_baseline_child_account.yml
@@ -1,0 +1,15 @@
+name: Post Baseline Child Accounts Custom Steps
+description: "Custom logic to run after baselineing new child accounts"
+inputs:
+  PIPELINES_READ_TOKEN:
+    description: "The GitHub token to use for checking out the infrastructure-live repo"
+    required: true
+  account_id:
+    description: "Child Account ID to operate on"
+    required: true
+  account_name:
+    description: "Child Account Name to operate on"
+    required: true
+  job:
+    description: "JSON of pipelines orchestrate job"
+    required: true

--- a/.github/custom_actions/post_baseline_core_account.yml
+++ b/.github/custom_actions/post_baseline_core_account.yml
@@ -13,4 +13,4 @@ runs:
     - name: Custom Logic Goes Here
       shell: bash
       run: |
-        echo 'hello world'
+        exit 0

--- a/.github/custom_actions/post_baseline_core_account.yml
+++ b/.github/custom_actions/post_baseline_core_account.yml
@@ -1,0 +1,16 @@
+name: Post Baseline Core Accounts Custom Steps
+description: "Custom logic to run after baselineing core accounts (management, logs, shared, security)"
+inputs:
+  PIPELINES_READ_TOKEN:
+    description: "The PIPELINES_READ_TOKEN secret"
+    required: true
+  gruntwork_context:
+    description: "Gruntwork Context From the Gruntwork Bootstrap step"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Custom Logic Goes Here
+      shell: bash
+      run: |
+        echo 'hello world'

--- a/.github/custom_actions/post_create_delegated_repo.yml
+++ b/.github/custom_actions/post_create_delegated_repo.yml
@@ -1,0 +1,22 @@
+name: Post create delegated repo custom action hooks
+description: "Custom logic to run after finishing creating a delegated repo"
+inputs:
+  ORG_REPO_ADMIN_TOKEN:
+    description: ""
+    required: true
+  PIPELINES_READ_TOKEN:
+    description: ""
+    required: true
+  gruntwork_context:
+    description: "Gruntwork Context From the Gruntwork Bootstrap step"
+    required: true
+  access_control_pull_request_url:
+    description: "URL to the access-control pull request"
+    required: true
+runs:
+  using: composite
+  steps:
+  - name: Custom Logic Goes Here
+    shell: bash
+    run: |
+      exit 0

--- a/.github/custom_actions/post_provision_new_account.yml
+++ b/.github/custom_actions/post_provision_new_account.yml
@@ -10,6 +10,9 @@ inputs:
   gruntwork_context:
     description: "Gruntwork Context From the Gruntwork Bootstrap step"
     required: true
+  baseline_pull_request_url:
+    description: "URL to the pull request for baselining the new account"
+    required: true
 runs:
   using: composite
   steps:

--- a/.github/custom_actions/post_provision_new_account.yml
+++ b/.github/custom_actions/post_provision_new_account.yml
@@ -16,4 +16,4 @@ runs:
     - name: Custom Logic Goes Here
       shell: bash
       run: |
-        echo 'hello world'
+        exit 0

--- a/.github/custom_actions/post_provision_new_account.yml
+++ b/.github/custom_actions/post_provision_new_account.yml
@@ -1,0 +1,19 @@
+name: Post Prevision New Account Custom Steps
+description: "Custom logic to run after account provisioning"
+inputs:
+  PIPELINES_READ_TOKEN:
+    description: "The PIPELINES_READ_TOKEN secret"
+    required: true
+  INFRA_ROOT_WRITE_TOKEN:
+    description: "The INFRA_ROOT_WRITE_TOKEN secret"
+    required: true
+  gruntwork_context:
+    description: "Gruntwork Context From the Gruntwork Bootstrap step"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Custom Logic Goes Here
+      shell: bash
+      run: |
+        echo 'hello world'

--- a/.github/custom_actions/pre_baseline_child_account.yml
+++ b/.github/custom_actions/pre_baseline_child_account.yml
@@ -13,3 +13,10 @@ inputs:
   job:
     description: "JSON of pipelines orchestrate job"
     required: true
+runs:
+  using: composite
+  steps:
+    - name: Custom Logic Goes Here
+      shell: bash
+      run: |
+        exit 0

--- a/.github/custom_actions/pre_baseline_child_account.yml
+++ b/.github/custom_actions/pre_baseline_child_account.yml
@@ -1,0 +1,15 @@
+name: Pre Baseline Child Accounts Custom Steps
+description: "Custom logic to run prior to baselineing new child accounts"
+inputs:
+  PIPELINES_READ_TOKEN:
+    description: "The GitHub token to use for checking out the infrastructure-live repo"
+    required: true
+  account_id:
+    description: "Child Account ID to operate on"
+    required: true
+  account_name:
+    description: "Child Account Name to operate on"
+    required: true
+  job:
+    description: "JSON of pipelines orchestrate job"
+    required: true

--- a/.github/custom_actions/pre_baseline_core_account.yml
+++ b/.github/custom_actions/pre_baseline_core_account.yml
@@ -1,0 +1,16 @@
+name: Pre Baseline Core Accounts Custom Steps
+description: "Custom logic to run prior to baselineing core accounts (management, logs, shared, security)"
+inputs:
+  PIPELINES_READ_TOKEN:
+    description: "The PIPELINES_READ_TOKEN secret"
+    required: true
+  gruntwork_context:
+    description: "Gruntwork Context From the Gruntwork Bootstrap step"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Custom Logic Goes Here
+      shell: bash
+      run: |
+        echo 'hello world'

--- a/.github/custom_actions/pre_baseline_core_account.yml
+++ b/.github/custom_actions/pre_baseline_core_account.yml
@@ -13,4 +13,4 @@ runs:
     - name: Custom Logic Goes Here
       shell: bash
       run: |
-        echo 'hello world'
+        exit 0

--- a/.github/custom_actions/pre_provision_new_account.yml
+++ b/.github/custom_actions/pre_provision_new_account.yml
@@ -16,4 +16,4 @@ runs:
     - name: Custom Logic Goes Here
       shell: bash
       run: |
-        echo 'hello world'
+        exit 0

--- a/.github/custom_actions/pre_provision_new_account.yml
+++ b/.github/custom_actions/pre_provision_new_account.yml
@@ -1,0 +1,19 @@
+name: Pre Provision New Account Custom Steps
+description: "Custom logic to run before account provisioning"
+inputs:
+  PIPELINES_READ_TOKEN:
+    description: "The PIPELINES_READ_TOKEN secret"
+    required: true
+  INFRA_ROOT_WRITE_TOKEN:
+    description: "The INFRA_ROOT_WRITE_TOKEN secret"
+    required: true
+  gruntwork_context:
+    description: "Gruntwork Context From the Gruntwork Bootstrap step"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Custom Logic Goes Here
+      shell: bash
+      run: |
+        echo 'hello world'

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -110,7 +110,7 @@ jobs:
           new_account_name: ${{ matrix.jobs.NewAccounts[0].Name }}
 
       - name: "[Baseline]: Pre Provision New Account Custom Action"
-        uses: ./custom_actions/pre-provision-new-account
+        uses: ./custom_actions/pre_provision_new_account
         if: ${{ steps.gruntwork_context.outputs.action == 'PROVISION_ACCOUNT' }}
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
@@ -127,15 +127,16 @@ jobs:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[Baseline]: Post Provision New Account Custom Action"
-        uses: ./custom_actions/post-provision-new-account
+        uses: ./custom_actions/post_provision_new_account
         if: ${{ steps.gruntwork_context.outputs.action == 'PROVISION_ACCOUNT' }}
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           INFRA_ROOT_WRITE_TOKEN: ${{ secrets.INFRA_ROOT_WRITE_TOKEN }}
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
+          pull_request_url: ${{ steps.provision_new_account.outputs.pull_request_url }}
 
       - name: "[Baseline]: Pre Baseline Core Account Action"
-        uses: ./custom_actions/pre-baseline-core-accounts
+        uses: ./custom_actions/pre_baseline_core_accounts
         if: steps.gruntwork_context.outputs.action == 'BASELINE_ACCOUNT'
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
@@ -152,7 +153,7 @@ jobs:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[Baseline]: Post Baseline Core Account Action"
-        uses: ./custom_actions/post-baseline-core-accounts
+        uses: ./custom_actions/post_baseline_core_accounts
         if: steps.gruntwork_context.outputs.action == 'BASELINE_ACCOUNT'
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
@@ -245,7 +246,7 @@ jobs:
           new_account_name: ${{ matrix.jobs.Name }}
 
       - name: "[Baseline]: Pre Baseline Child Account Action"
-        uses: ./custom_actions/pre-baseline-child-account
+        uses: ./custom_actions/pre_baseline_child_account
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           account_id: ${{ matrix.jobs.ID }}
@@ -264,7 +265,7 @@ jobs:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[Baseline]: Post Baseline Child Account Action"
-        uses: ./custom_actions/post-baseline-child-account
+        uses: ./custom_actions/post_baseline_child_account
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           account_id: ${{ matrix.jobs.ID }}
@@ -339,7 +340,7 @@ jobs:
           ORG_REPO_ADMIN_TOKEN: ${{ secrets.ORG_REPO_ADMIN_TOKEN }}
 
       - name: "Post create delegated repo custom actions"
-        uses: ./custom_actions/post-create-delegated-repo
+        uses: ./custom_actions/post_create_delegated_repo
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
           access_control_pull_request_url: ${{ steps.access_control_pr.outputs.pull_request_url }}

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -111,11 +111,11 @@ jobs:
 
       - name: "[Baseline]: Pre Provision New Account Custom Action"
         uses: ./custom_actions/pre-provision-new-account
-        if: ${{ steps.bootstrap.outputs.action == 'PROVISION_ACCOUNT' }}
+        if: ${{ steps.gruntwork_context.outputs.action == 'PROVISION_ACCOUNT' }}
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           INFRA_ROOT_WRITE_TOKEN: ${{ secrets.INFRA_ROOT_WRITE_TOKEN }}
-          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
+          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[ProvisionAccount]: Provision New Account"
         id: provision_new_account
@@ -128,18 +128,18 @@ jobs:
 
       - name: "[Baseline]: Post Provision New Account Custom Action"
         uses: ./custom_actions/post-provision-new-account
-        if: ${{ steps.bootstrap.outputs.action == 'PROVISION_ACCOUNT' }}
+        if: ${{ steps.gruntwork_context.outputs.action == 'PROVISION_ACCOUNT' }}
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           INFRA_ROOT_WRITE_TOKEN: ${{ secrets.INFRA_ROOT_WRITE_TOKEN }}
-          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
+          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[Baseline]: Pre Baseline Core Account Action"
         uses: ./custom_actions/pre-baseline-core-accounts
-        if: steps.bootstrap.outputs.action == 'BASELINE_ACCOUNT'
+        if: steps.gruntwork_context.outputs.action == 'BASELINE_ACCOUNT'
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
-          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
+          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       # Run the core accounts baselines(shared, logs, security, etc. to ensure the account is setup correctly)
       - name: "Run core accounts baselines"
@@ -153,10 +153,10 @@ jobs:
 
       - name: "[Baseline]: Post Baseline Core Account Action"
         uses: ./custom_actions/post-baseline-core-accounts
-        if: steps.bootstrap.outputs.action == 'BASELINE_ACCOUNT'
+        if: steps.gruntwork_context.outputs.action == 'BASELINE_ACCOUNT'
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
-          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
+          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[TerragruntExecute]: Authenticate with AWS and then Invoke Terragrunt"
         id: terragrunt
@@ -173,7 +173,7 @@ jobs:
           gruntwork_config_file: ${{ steps.gruntwork_context.outputs.gruntwork_config_file }}
           infra_live_repo: "."
           infra_live_directory: "."
-          deploy_branch_name: ${{ steps.bootstrap.outputs.deploy_branch_name }}
+          deploy_branch_name: ${{ steps.gruntwork_context.outputs.deploy_branch_name }}
 
       - name: Update comment
         uses: ./pipelines-actions/.github/actions/pipelines-status-update

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -335,3 +335,11 @@ jobs:
           access_control_pull_request_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ secrets.ORG_REPO_ADMIN_TOKEN }}
+
+      - name: "Post create delegated repo custom actions"
+        uses: ./custom_actions/post-create-delegated-repo
+        with:
+          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
+          access_control_pull_request_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
+          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
+          ORG_REPO_ADMIN_TOKEN: ${{ secrets.ORG_REPO_ADMIN_TOKEN }}

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -133,7 +133,7 @@ jobs:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           INFRA_ROOT_WRITE_TOKEN: ${{ secrets.INFRA_ROOT_WRITE_TOKEN }}
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
-          pull_request_url: ${{ steps.provision_new_account.outputs.pull_request_url }}
+          baseline_pull_request_url: ${{ steps.provision_new_account.outputs.pull_request_url }}
 
       - name: "[Baseline]: Pre Baseline Core Account Action"
         uses: ./custom_actions/pre_baseline_core_accounts

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -270,6 +270,7 @@ jobs:
           account_id: ${{ matrix.jobs.ID }}
           account_name: ${{ matrix.jobs.Name }}
           job: ${{ toJson(fromJson(needs.detect_changes.outputs.pipelines_jobs)[0]) }}
+          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: Update comment
         uses: ./pipelines-actions/.github/actions/pipelines-status-update

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -251,6 +251,7 @@ jobs:
           account_id: ${{ matrix.jobs.ID }}
           account_name: ${{ matrix.jobs.Name }}
           job: ${{ toJson(fromJson(needs.detect_changes.outputs.pipelines_jobs)[0]) }}
+          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[Baseline]: Baseline the Child Account"
         id: baseline_child_account

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -343,3 +343,4 @@ jobs:
           access_control_pull_request_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ secrets.ORG_REPO_ADMIN_TOKEN }}
+          delegated_repo_pull_request_url: ${{ steps.provision_delegated_repo.outputs.pull_request_url }}

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -109,6 +109,14 @@ jobs:
           # TODO: This should be "first_new_account_name".
           new_account_name: ${{ matrix.jobs.NewAccounts[0].Name }}
 
+      - name: "[Baseline]: Pre Provision New Account Custom Action"
+        uses: ./custom_actions/pre-provision-new-account
+        if: ${{ steps.bootstrap.outputs.action == 'PROVISION_ACCOUNT' }}
+        with:
+          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
+          INFRA_ROOT_WRITE_TOKEN: ${{ secrets.INFRA_ROOT_WRITE_TOKEN }}
+          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
+
       - name: "[ProvisionAccount]: Provision New Account"
         id: provision_new_account
         if: ${{ steps.gruntwork_context.outputs.action == 'PROVISION_ACCOUNT' }}
@@ -117,6 +125,21 @@ jobs:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           INFRA_ROOT_WRITE_TOKEN: ${{ secrets.INFRA_ROOT_WRITE_TOKEN }}
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
+
+      - name: "[Baseline]: Post Provision New Account Custom Action"
+        uses: ./custom_actions/post-provision-new-account
+        if: ${{ steps.bootstrap.outputs.action == 'PROVISION_ACCOUNT' }}
+        with:
+          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
+          INFRA_ROOT_WRITE_TOKEN: ${{ secrets.INFRA_ROOT_WRITE_TOKEN }}
+          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
+
+      - name: "[Baseline]: Pre Baseline Core Account Action"
+        uses: ./custom_actions/pre-baseline-core-accounts
+        if: steps.bootstrap.outputs.action == 'BASELINE_ACCOUNT'
+        with:
+          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
+          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
 
       # Run the core accounts baselines(shared, logs, security, etc. to ensure the account is setup correctly)
       - name: "Run core accounts baselines"
@@ -127,6 +150,13 @@ jobs:
         with:
           PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
+
+      - name: "[Baseline]: Post Baseline Core Account Action"
+        uses: ./custom_actions/post-baseline-core-accounts
+        if: steps.bootstrap.outputs.action == 'BASELINE_ACCOUNT'
+        with:
+          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
+          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
 
       - name: "[TerragruntExecute]: Authenticate with AWS and then Invoke Terragrunt"
         id: terragrunt
@@ -214,6 +244,14 @@ jobs:
           child_account_id: ${{ matrix.jobs.ID }}
           new_account_name: ${{ matrix.jobs.Name }}
 
+      - name: "[Baseline]: Pre Baseline Child Account Action"
+        uses: ./custom_actions/pre-baseline-child-account
+        with:
+          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
+          account_id: ${{ matrix.jobs.ID }}
+          account_name: ${{ matrix.jobs.Name }}
+          job: ${{ toJson(fromJson(needs.detect_changes.outputs.pipelines_jobs)[0]) }}
+
       - name: "[Baseline]: Baseline the Child Account"
         id: baseline_child_account
         uses: ./pipelines-actions/.github/actions/pipelines-baseline-child-account-action
@@ -223,6 +261,14 @@ jobs:
           account_name: ${{ matrix.jobs.Name }}
           job: ${{ toJson(fromJson(needs.detect_changes.outputs.pipelines_jobs)[0]) }}
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
+
+      - name: "[Baseline]: Post Baseline Child Account Action"
+        uses: ./custom_actions/post-baseline-child-account
+        with:
+          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
+          account_id: ${{ matrix.jobs.ID }}
+          account_name: ${{ matrix.jobs.Name }}
+          job: ${{ toJson(fromJson(needs.detect_changes.outputs.pipelines_jobs)[0]) }}
 
       - name: Update comment
         uses: ./pipelines-actions/.github/actions/pipelines-status-update


### PR DESCRIPTION
This PR introduces a set of new "pre" and "post" hooks inside pipelines-root around account factory workflows.  The goal is to setup a reasonably well-defined contract between pipelines and any customizations that customers apply, and also to provide a physical location for those customizations that is nearly impossible to cause merge conflicts on future pipelines releases.  This is accomplished by adding steps to the core pipelines workflows that call out to external composite action files that do nothing by default, but provide an opportunity to write arbitrary action code.
