### PR TITLE
fix: Adjusting delegated workflow so that it uses dynamic authentication too

### DIFF
--- a/.github/workflows/pipelines-delegated.yml
+++ b/.github/workflows/pipelines-delegated.yml
@@ -105,14 +105,19 @@ jobs:
 
       - name: "Run terragrunt ${{ steps.bootstrap.outputs.terragrunt_command }} in ${{ steps.bootstrap.outputs.working_directory }}"
         id: terragrunt
-        uses: ./pipelines-actions/.github/actions/pipelines-aws-execute
+        uses: ./pipelines-actions/.github/actions/pipelines-execute
+        env:
+          TERRAGRUNT_AUTH_PROVIDER_CMD: 'pipelines auth terragrunt-credentials --ci github-actions --cloud aws --wd .'
         with:
-          PIPELINES_READ_TOKEN: ${{ secrets.PIPELINES_READ_TOKEN }}
-          account_id: ${{ steps.bootstrap.outputs.account_id }}
-          account_role_name: ${{ steps.bootstrap.outputs.role_name }}
-          role_session_name: ${{ steps.bootstrap.outputs.role_session_name }}
-          working_directory: ${{ steps.bootstrap.outputs.working_directory }}
-          gruntwork_context: ${{ toJson(steps.bootstrap.outputs) }}
+          token: ${{ secrets.PIPELINES_READ_TOKEN }}
+          tf_binary: ${{ steps.gruntwork_context.outputs.tf_binary }}
+          working_directory: ${{ steps.gruntwork_context.outputs.working_directory }}
+          terragrunt_command: ${{ steps.gruntwork_context.outputs.terragrunt_command }}
+          infra_live_repo_branch: ${{ steps.gruntwork_context.outputs.branch }}
+          gruntwork_config_file: ${{ steps.gruntwork_context.outputs.gruntwork_config_file }}
+          infra_live_repo: "."
+          infra_live_directory: "."
+          deploy_branch_name: ${{ steps.gruntwork_context.outputs.deploy_branch_name }}
 
       - name: Update comment
         if: always()


### PR DESCRIPTION
I'm not sure if there was a reason we didn't do this before, but if not, we should make the delegated workflow work like the root workflow for Terragrunt executions.