### PR TITLE
DEV-786 - Allow org_repo_admin fetch to fail on orchestrate

### DIFF
--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Fetch Org Repo Admin Token
         id: pipelines-org-repo-admin-token
         uses: gruntwork-io/pipelines-credentials@v1
+        continue-on-error: true
         with:
           PIPELINES_TOKEN_PATH: org-repo-admin/${{ github.repository_owner }}
           FALLBACK_TOKEN: ${{ secrets.ORG_REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
Screenshot showing the [workflow](https://github.com/gruntwork-test/e2e2-infrastructure-live-root/actions/runs/13462725565/job/37621992803) continuing even if the org repo token step fails.

![image](https://github.com/user-attachments/assets/42eefce5-707a-4819-9708-343cbc047163)
