### PR TITLE
Add github server for actions

### DIFF
--- a/.github/workflows/pipelines-drift-detection.yml
+++ b/.github/workflows/pipelines-drift-detection.yml
@@ -72,7 +72,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -106,7 +106,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Validate PIPELINES_READ_TOKEN
         if: always() && steps.checkout_actions.conclusion != 'success'
@@ -204,7 +204,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4
@@ -396,7 +396,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4
@@ -520,7 +520,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4

--- a/.github/workflows/pipelines-unlock.yml
+++ b/.github/workflows/pipelines-unlock.yml
@@ -73,7 +73,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4
@@ -287,7 +287,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -88,7 +88,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Validate PIPELINES_READ_TOKEN
         if: always() && steps.checkout_actions.conclusion != 'success'
@@ -184,7 +184,7 @@ jobs:
           repository: gruntwork-io/pipelines-actions
           ref: ${{ env.PIPELINES_ACTIONS_VERSION }}
           token: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
-          github-server-url: github.com
+          github-server-url: https://github.com
 
       - name: Check out repo code
         uses: actions/checkout@v4


### PR DESCRIPTION
When running on GHES we must specify that we want to use `github.com` as the server when checking out actions (unless the client has cloned/forked the repo into their own GHES, in which case the repo name likey has to change)