### PR TITLE
Use pipelines binary for delegated repo setup

### DIFF
--- a/.github/workflows/pipelines-drift-detection.yml
+++ b/.github/workflows/pipelines-drift-detection.yml
@@ -36,7 +36,7 @@ on:
         description: "Override where we fetch pipelines from, used for internal testing"
       pipelines_cli_version:
         type: string
-        default: "v0.40.0-rc17"
+        default: "v0.40.0-rc25"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_ref:
         type: string

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -643,7 +643,6 @@ jobs:
         id: access_control_account
         uses: ./pipelines-actions/.github/actions/pipelines-provision-access-control-action
         with:
-          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
           job: ${{ toJson(fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0]) }}
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}
@@ -653,9 +652,9 @@ jobs:
         id: provision_delegated_repo
         uses: ./pipelines-actions/.github/actions/pipelines-provision-repo-action
         with:
-          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
           job: ${{ toJson(fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0]) }}
           access_control_pull_request_url: ${{ steps.access_control_account.outputs.pull_request_url }}
+          new_account_name: ${{ fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0].NewAccounts[0].Name }}
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
@@ -673,11 +672,10 @@ jobs:
       - name: "Create delegated repo pull request"
         uses: ./pipelines-actions/.github/actions/pipelines-new-pr-action
         with:
-          GH_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
+          job: ${{ toJson(fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0]) }}
           delegated_repo_path: ${{ steps.provision_delegated_repo.outputs.delegated_repo_path }}
-          delegated_repo_name: ${{ steps.provision_delegated_repo.outputs.delegated_repo_name }}
-          requesting_pr_number: ${{ steps.provision_delegated_repo.outputs.requesting_pr_number || 131 }} # TODO: Remove hardcoded number neccessary due to testing on unmerged PR by testing
           access_control_pr_url: ${{ steps.access_control_account.outputs.pull_request_url }}
+          GH_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
 
   pipelines_status_check:
     name: "Pipelines Status Check"

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -320,7 +320,6 @@ jobs:
           PR_COMMENT_WRITE_TOKEN: ${{ steps.pipelines-propose-infra-change-token.outputs.PIPELINES_TOKEN }}
           job: ${{ toJson(matrix.jobs) }}
           workflow_job_name: ${{ env.JOB_NAME }}
-          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
 
       - name: "[ProvisionAccount]: Post Provision New Account Custom Action"
         uses: ./pipelines-actions/.github/custom-actions/post-provision-new-account

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -34,7 +34,7 @@ on:
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_ref:
         type: string
-        default: "main"
+        default: "use-pipelines-for-delegated-repo-setup"
         description: "For Gruntwork internal testing - the ref of the pipelines actions to use"
       pipelines_credentials_ref:
         type: string
@@ -644,6 +644,7 @@ jobs:
         uses: ./pipelines-actions/.github/actions/pipelines-provision-access-control-action
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
+          job: ${{ toJson(fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0]) }}
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -641,6 +641,7 @@ jobs:
 
       - name: "Create Access Control PR"
         id: access_control_pr
+        if: ${{ contains(steps.gruntwork_context.outputs.terragrunt_command , 'apply') }}
         uses: ./pipelines-actions/.github/actions/pipelines-provision-access-control-action
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
@@ -654,6 +655,7 @@ jobs:
         uses: ./pipelines-actions/.github/actions/pipelines-provision-repo-action
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
+          job: ${{ toJson(fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0]) }}
           access_control_pull_request_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -558,7 +558,7 @@ jobs:
     needs: [pipelines_orchestrate, pipelines_apply_baselines, pipelines_execute]
     runs-on: ${{ fromJSON(inputs.runner) }}
     # GHA can't check for length, so we just check if there is an item in the 0 index
-    if: ${{ fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0].NewAccounts[0] != null && needs.pipelines_execute.outputs.delegate_management == 'true' && needs.pipelines_execute.outputs.terragrunt_command == 'run-all apply' }}
+    if: ${{ fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0].NewAccounts[0] != null && needs.pipelines_execute.outputs.delegate_management == 'true' && contains(needs.pipelines_execute.outputs.terragrunt_command, 'apply') }}
     steps:
       - name: Record workflow env vars
         env:

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -670,13 +670,13 @@ jobs:
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
 
-      - name: "Create Delegated Repo PR"
+      - name: "Create delegated repo pull request"
         uses: ./pipelines-actions/.github/actions/pipelines-new-pr-action
         with:
           GH_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
           delegated_repo_path: ${{ steps.provision_delegated_repo.outputs.delegated_repo_path }}
           delegated_repo_name: ${{ steps.provision_delegated_repo.outputs.delegated_repo_name }}
-          requesting_pr_number: ${{ steps.provision_delegated_repo.outputs.requesting_pr_number }}
+          requesting_pr_number: ${{ steps.provision_delegated_repo.outputs.requesting_pr_number || 131 }} # TODO: Remove hardcoded number neccessary due to testing on unmerged PR by testing
           access_control_pr_url: ${{ steps.access_control_account.outputs.pull_request_url }}
 
   pipelines_status_check:

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -639,8 +639,8 @@ jobs:
           # the delegated_repo_name (which is the same in all the new request files)
           new_account_name: ${{ fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0].NewAccounts[0].Name }}
 
-      - name: "Create Access Control PR"
-        id: access_control_pr
+      - name: "Provision access control account(s) and create PR"
+        id: access_control_account
         uses: ./pipelines-actions/.github/actions/pipelines-provision-access-control-action
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
@@ -649,13 +649,13 @@ jobs:
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
 
-      - name: "Create and bootstrap delegated Repo"
+      - name: "Create delegated repo and bootstrap"
         id: provision_delegated_repo
         uses: ./pipelines-actions/.github/actions/pipelines-provision-repo-action
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
           job: ${{ toJson(fromJson(needs.pipelines_orchestrate.outputs.pipelines_jobs)[0]) }}
-          access_control_pull_request_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
+          access_control_pull_request_url: ${{ steps.access_control_account.outputs.pull_request_url }}
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
@@ -665,7 +665,7 @@ jobs:
         uses: ./pipelines-actions/.github/custom-actions/post-create-delegated-repo
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
-          access_control_pull_request_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
+          access_control_pull_request_url: ${{ steps.access_control_account.outputs.pull_request_url }}
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ steps.pipelines-gruntwork-read-token.outputs.PIPELINES_TOKEN }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ steps.pipelines-customer-org-read-token.outputs.PIPELINES_TOKEN }}
           ORG_REPO_ADMIN_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
@@ -677,7 +677,7 @@ jobs:
           delegated_repo_path: ${{ steps.provision_delegated_repo.outputs.delegated_repo_path }}
           delegated_repo_name: ${{ steps.provision_delegated_repo.outputs.delegated_repo_name }}
           requesting_pr_number: ${{ steps.provision_delegated_repo.outputs.requesting_pr_number }}
-          access_control_pr_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
+          access_control_pr_url: ${{ steps.access_control_account.outputs.pull_request_url }}
 
   pipelines_status_check:
     name: "Pipelines Status Check"

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -641,7 +641,6 @@ jobs:
 
       - name: "Create Access Control PR"
         id: access_control_pr
-        if: ${{ contains(steps.gruntwork_context.outputs.terragrunt_command , 'apply') }}
         uses: ./pipelines-actions/.github/actions/pipelines-provision-access-control-action
         with:
           gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
@@ -674,14 +673,11 @@ jobs:
       - name: "Create Delegated Repo PR"
         uses: ./pipelines-actions/.github/actions/pipelines-new-pr-action
         with:
-          gruntwork_context: ${{ toJson(steps.gruntwork_context.outputs) }}
           GH_TOKEN: ${{ steps.pipelines-org-repo-admin-token.outputs.PIPELINES_TOKEN }}
-          path: ${{ steps.provision_delegated_repo.outputs.path }}
-          new_branch_name: ${{ steps.provision_delegated_repo.outputs.new_branch_name }}
-          commit_message: ${{ steps.provision_delegated_repo.outputs.commit_message }}
-          pr_body: ${{ steps.provision_delegated_repo.outputs.pr_body }}
+          delegated_repo_path: ${{ steps.provision_delegated_repo.outputs.delegated_repo_path }}
+          delegated_repo_name: ${{ steps.provision_delegated_repo.outputs.delegated_repo_name }}
           requesting_pr_number: ${{ steps.provision_delegated_repo.outputs.requesting_pr_number }}
-          step_summary_content: ${{ steps.provision_delegated_repo.outputs.step_summary_content }}
+          access_control_pr_url: ${{ steps.access_control_pr.outputs.pull_request_url }}
 
   pipelines_status_check:
     name: "Pipelines Status Check"

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -30,11 +30,11 @@ on:
         description: "Override where we fetch pipelines from, used for internal testing"
       pipelines_cli_version:
         type: string
-        default: "v0.40.0-rc17"
+        default: "v0.40.0-rc25"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_ref:
         type: string
-        default: "use-pipelines-for-delegated-repo-setup"
+        default: "main"
         description: "For Gruntwork internal testing - the ref of the pipelines actions to use"
       pipelines_credentials_ref:
         type: string

--- a/.github/workflows/pipelines-unlock.yml
+++ b/.github/workflows/pipelines-unlock.yml
@@ -43,7 +43,7 @@ on:
         default: '"ubuntu-latest"'
       pipelines_cli_version:
         type: string
-        default: "v0.40.0-rc17"
+        default: "v0.40.0-rc25"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_ref:
         type: string

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -30,7 +30,7 @@ on:
         description: "Override where we fetch pipelines from, used for internal testing"
       pipelines_cli_version:
         type: string
-        default: "v0.40.0-rc17"
+        default: "v0.40.0-rc25"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_ref:
         type: string


### PR DESCRIPTION
Changes tested in Pipelines Enterprise Account factory tests updated to reference current changes [in this PR](https://github.com/gruntwork-io/pipelines/pull/477).
[E2E Test-created Account baselines PR for delegated repository](https://github.com/gruntwork-test/infra-live-e2e-20251005234550-1852-1/pull/3)

## TODO
- [x] Settle on strategy for checking pipelines status that fails if delegated repository setup fails
- [x] Revert [temporary changes](https://github.com/gruntwork-io/pipelines-workflows/pull/151/commits/82a6b3b584fdf8fb521eeff86978b48f8a63aae1) made to test delegated repository on unmerged PR.
