### PR TITLE
Revert "chore: Bumping `mise` version to `2025.10.0`"

### DIFF
--- a/.github/workflows/pipelines-drift-detection.yml
+++ b/.github/workflows/pipelines-drift-detection.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2024.10.8
           working_directory: "./infra-live-repo"
 
       - name: Install Pipelines CLI
@@ -202,7 +202,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2024.10.8
           working_directory: "./infra-live-repo"
 
       - name: Install Pipelines CLI

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -290,7 +290,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2024.10.8
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth
@@ -499,7 +499,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2024.10.8
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth

--- a/.github/workflows/pipelines-unlock.yml
+++ b/.github/workflows/pipelines-unlock.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2024.10.8
           mise_toml: "${{ steps.mise-toml.outputs.TOML }}"
 
       - name: Test Terraform, OpenTofu and Terragrunt
@@ -280,7 +280,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2024.10.8
           mise_toml: "${{ steps.mise-toml.outputs.TOML }}"
 
       - name: Test Terraform, OpenTofu and Terragrunt


### PR DESCRIPTION
Immediate regret merging this so late on a Friday. Reverting until Monday.