### PR TITLE
Automate major version floating tag updates

### DIFF
--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -1,0 +1,32 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-tag:
+    # Skip pre-releases
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Update major version tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          MAJOR=$(echo "$TAG" | grep -oP '^v\d+')
+          if [ -z "$MAJOR" ]; then
+            echo "::error::Could not extract major version from tag '$TAG'"
+            exit 1
+          fi
+          echo "Updating floating tag $MAJOR to point to $TAG"
+          git tag -f "$MAJOR" "$TAG"
+          git push -f origin "$MAJOR"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically updates the major version floating tag (e.g. `v4`) whenever a new release is published
- Pre-releases are skipped
- Closes #7

## How it works
On `release` → `published`, the workflow extracts the major version from the tag name (e.g. `v4` from `v4.12.0`) and force-pushes the floating tag to point to it.

## Test plan
- [ ] Verify the workflow file is valid YAML and the trigger/permissions are correct
- [ ] After merging, create a test release and confirm the floating tag is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)