### PR TITLE
Bump mise from 2025.10.0 to 2026.4.11

### DIFF
--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -251,7 +251,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2026.4.11
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth
@@ -436,7 +436,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2025.10.0
+          version: 2026.4.11
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth


### PR DESCRIPTION
## Summary

- Bump mise from `2025.10.0` to `2026.4.11` in both mise-action invocations
- Enables `.miserc.toml` support (2026.1.x) and Tera templates in `.miserc.toml` (2026.4.6)

Closes #208

## Motivation

Repos with dev-only tools that have `postinstall` hooks (e.g. prek) fail during `mise install` on CI. The fix is to use `.miserc.toml` with Tera templates to conditionally set `MISE_ENV=ci`, loading a restricted `.mise.ci.toml` with `enable_tools`. This requires mise ≥ 2026.4.6.

See #208 for full details.