### PR TITLE
Pipelines CLI v0.53.1

### DIFF
--- a/.github/workflows/pipelines-drift-detection.yml
+++ b/.github/workflows/pipelines-drift-detection.yml
@@ -36,7 +36,7 @@ on:
         description: "Override where we fetch pipelines from, used for internal testing"
       pipelines_cli_version:
         type: string
-        default: "v0.53.0"
+        default: "v0.53.1"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_repo:
         type: string

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -30,7 +30,7 @@ on:
         description: "Override where we fetch pipelines from, used for internal testing"
       pipelines_cli_version:
         type: string
-        default: "v0.53.0"
+        default: "v0.53.1"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_repo:
         type: string

--- a/.github/workflows/pipelines-unlock.yml
+++ b/.github/workflows/pipelines-unlock.yml
@@ -47,7 +47,7 @@ on:
         description: "Override where we fetch pipelines from, used for internal testing"
       pipelines_cli_version:
         type: string
-        default: "v0.53.0"
+        default: "v0.53.1"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_repo:
         type: string

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -30,7 +30,7 @@ on:
         description: "Override where we fetch pipelines from, used for internal testing"
       pipelines_cli_version:
         type: string
-        default: "v0.53.0"
+        default: "v0.53.1"
         description: "For Gruntwork internal testing - the version of the pipelines CLI to use"
       pipelines_actions_repo:
         type: string


### PR DESCRIPTION
## Summary

- Bump pipelines CLI default version from v0.53.0 to v0.53.1
- v0.53.1 reflects output-only changes in plan summary