### PR TITLE
Set PR status labels at end of pipelines run (PF-126)

### DIFF
--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -56,6 +56,10 @@ on:
         type: string
         default: "v2.0.0"
         description: "For Gruntwork internal testing - the ref of the pipelines credentials to use"
+      pipelines_pr_label_prefix:
+        type: string
+        default: "pipelines/"
+        description: "Prefix for PR status labels (e.g. pipelines/plan-success). Override to namespace under a different prefix."
 
     secrets:
       PIPELINES_READ_TOKEN:
@@ -721,6 +725,7 @@ jobs:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
 
       - name: Check Status
+        id: check_status
         shell: bash
         working-directory: ./infra-live-repo
         env:
@@ -735,6 +740,7 @@ jobs:
           pipelines inventory usage --working-directory . || true
 
           pipeline_status=$(jq -r '.status' </tmp/finalize-output.json)
+          echo "pipeline_status=$pipeline_status" >>"$GITHUB_OUTPUT"
 
           cat /tmp/finalize-output.json
 
@@ -747,3 +753,17 @@ jobs:
             echo -e "❌ \033[1;31mPipeline Failed\033[0m"
             exit 1
           fi
+
+      # Keep in sync with pipelines.yml (same step at end of pipelines_status_check).
+      - name: Set PR status label
+        if: always()
+        uses: ./pipelines-actions/.github/actions/pipelines-pr-labels
+        with:
+          PR_COMMENT_WRITE_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).propose_infra_change }}
+          # If pipeline_status is empty (finalize never ran because of an earlier
+          # catastrophic failure), default to failure so the PR gets a label
+          # rather than going unlabeled, which is exactly the case customers
+          # most want to spot at a glance.
+          status: ${{ steps.check_status.outputs.pipeline_status || 'failure' }}
+          event_kind: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && 'plan' || 'apply' }}
+          label_prefix: ${{ inputs.pipelines_pr_label_prefix }}

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -48,6 +48,10 @@ on:
         type: string
         default: "v2.0.0"
         description: "For Gruntwork internal testing - the ref of the pipelines credentials to use"
+      pipelines_pr_label_prefix:
+        type: string
+        default: "pipelines/"
+        description: "Prefix for PR status labels (e.g. pipelines/plan-success). Override to namespace under a different prefix."
 
     secrets:
       PIPELINES_READ_TOKEN:
@@ -336,6 +340,7 @@ jobs:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
 
       - name: Check Status
+        id: check_status
         shell: bash
         working-directory: ./infra-live-repo
         env:
@@ -350,6 +355,7 @@ jobs:
           pipelines inventory usage --working-directory . || true
 
           pipeline_status=$(jq -r '.status' </tmp/finalize-output.json)
+          echo "pipeline_status=$pipeline_status" >>"$GITHUB_OUTPUT"
 
           cat /tmp/finalize-output.json
 
@@ -362,3 +368,17 @@ jobs:
             echo -e "❌ \033[1;31mPipeline Failed\033[0m"
             exit 1
           fi
+
+      # Keep in sync with pipelines-root.yml (same step at end of pipelines_status_check).
+      - name: Set PR status label
+        if: always()
+        uses: ./pipelines-actions/.github/actions/pipelines-pr-labels
+        with:
+          PR_COMMENT_WRITE_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).propose_infra_change }}
+          # If pipeline_status is empty (finalize never ran because of an earlier
+          # catastrophic failure), default to failure so the PR gets a label
+          # rather than going unlabeled, which is exactly the case customers
+          # most want to spot at a glance.
+          status: ${{ steps.check_status.outputs.pipeline_status || 'failure' }}
+          event_kind: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && 'plan' || 'apply' }}
+          label_prefix: ${{ inputs.pipelines_pr_label_prefix }}


### PR DESCRIPTION
Wires the `pipelines-pr-labels` composite action into `pipelines.yml` and `pipelines-root.yml`. Adds workflow input `pipelines_pr_label_prefix` (default `pipelines/`) so customers can renamespace.

Status falls back to `failure` when `pipelines status-update finalize` never produced an output (orchestrate crash, checkout failure, runner OOM), so the PR still gets a `*-failed` label in the case customers most want to spot.

Linear: [PF-126](https://linear.app/gruntwork/issue/PF-126)
Depends on: [gruntwork-io/pipelines-actions#160](https://github.com/gruntwork-io/pipelines-actions/pull/160) (composite action) and [gruntwork-io/pipelines#590](https://github.com/gruntwork-io/pipelines/pull/590) (Go subcommand). Drift-detection PR labeling is out of scope for v1.

## Before merge

- Land gruntwork-io/pipelines#590 and cut a `pipelines-cli` release
- Land gruntwork-io/pipelines-actions#160 and tag a `pipelines-actions` release
- Bump `pipelines_actions_ref` default in this PR to that tag