### PR TITLE
Set CHANGE_TYPE env on execute job

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -180,6 +180,7 @@ jobs:
   pipelines_execute:
     env:
       JOB_NAME: ${{ contains(matrix.jobs.Action.Command, 'plan') && 'Plan' || 'Apply' }} - ${{ matrix.jobs.ChangeType }} - ${{ matrix.jobs.WorkingDirectory }}
+      CHANGE_TYPE: ${{ matrix.jobs.ChangeType }}
     name: ${{ contains(matrix.jobs.Action.Command, 'plan') && 'Plan' || 'Apply' }} - ${{ matrix.jobs.ChangeType }} - ${{ matrix.jobs.WorkingDirectory }}
     needs: [pipelines_orchestrate]
     runs-on: ${{ fromJSON(inputs.runner) }}

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -180,7 +180,6 @@ jobs:
   pipelines_execute:
     env:
       JOB_NAME: ${{ contains(matrix.jobs.Action.Command, 'plan') && 'Plan' || 'Apply' }} - ${{ matrix.jobs.ChangeType }} - ${{ matrix.jobs.WorkingDirectory }}
-      CHANGE_TYPE: ${{ matrix.jobs.ChangeType }}
     name: ${{ contains(matrix.jobs.Action.Command, 'plan') && 'Plan' || 'Apply' }} - ${{ matrix.jobs.ChangeType }} - ${{ matrix.jobs.WorkingDirectory }}
     needs: [pipelines_orchestrate]
     runs-on: ${{ fromJSON(inputs.runner) }}
@@ -261,6 +260,8 @@ jobs:
       - name: "[TerragruntExecute]: Run terragrunt ${{ matrix.jobs.Action.Command }} in ${{ matrix.jobs.WorkingDirectory }}"
         id: terragrunt
         uses: ./pipelines-actions/.github/actions/pipelines-execute
+        env:
+          CHANGE_TYPE: ${{ matrix.jobs.ChangeType }}
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}


### PR DESCRIPTION
The pipelines execute terragrunt command resolves its change type from the --infra-change-type flag or, as a fallback, the CHANGE_TYPE env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline execution to pass the change type directly into the execution step during runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->