### PR TITLE
PF-173: Add logs as artifact for a job

### DIFF
--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -386,6 +386,27 @@ jobs:
           ref: ${{ matrix.jobs.Ref }}
           stack_paths: ${{ toJson(matrix.jobs.StackPaths) }}
 
+      - name: Sanitize artifact name fragment
+        id: artifact_name
+        if: ${{ always() && (matrix.jobs.ChangeType != 'AccountsRequested') && (matrix.jobs.ChangeType != 'AccountsAdded') && steps.terragrunt.outputs.pipelines_logs_artifact_path != '' }}
+        shell: bash
+        env:
+          WORKING_DIRECTORY: ${{ matrix.jobs.WorkingDirectory }}
+        run: |
+          sanitized="${WORKING_DIRECTORY//\//-}"
+          echo "fragment=$sanitized" >> "$GITHUB_OUTPUT"
+
+      - name: Upload unit logs as artifact
+        id: upload_logs
+        if: ${{ always() && (matrix.jobs.ChangeType != 'AccountsRequested') && (matrix.jobs.ChangeType != 'AccountsAdded') && steps.terragrunt.outputs.pipelines_logs_artifact_path != '' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: pipelines-logs-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jobs.ChangeType }}-${{ steps.artifact_name.outputs.fragment }}
+          path: ${{ steps.terragrunt.outputs.pipelines_logs_artifact_path }}
+          if-no-files-found: warn
+          retention-days: 30
+          overwrite: true
+
       - name: Update comment
         if: always() && (matrix.jobs.ChangeType != 'AccountsRequested') && (matrix.jobs.ChangeType != 'AccountsAdded')
         uses: ./pipelines-actions/.github/actions/pipelines-comment-job-update
@@ -399,6 +420,7 @@ jobs:
           plan_apply_log_file_path: ${{ steps.terragrunt.outputs.plan_folder }}
           extended_log_file_path: ${{ steps.terragrunt.outputs.execute_stdout_log }}
           pipelines_report_file_path: ${{ steps.terragrunt.outputs.pipelines_report_file_path }}
+          logs_artifact_url: ${{ steps.upload_logs.outputs.artifact-url }}
           job_name: ${{ env.JOB_NAME }}
 
     outputs:

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -270,6 +270,27 @@ jobs:
           ref: ${{ matrix.jobs.Ref }}
           stack_paths: ${{ toJson(matrix.jobs.StackPaths) }}
 
+      - name: Sanitize artifact name fragment
+        id: artifact_name
+        if: ${{ always() && steps.terragrunt.outputs.pipelines_logs_artifact_path != '' }}
+        shell: bash
+        env:
+          WORKING_DIRECTORY: ${{ matrix.jobs.WorkingDirectory }}
+        run: |
+          sanitized="${WORKING_DIRECTORY//\//-}"
+          echo "fragment=$sanitized" >> "$GITHUB_OUTPUT"
+
+      - name: Upload unit logs as artifact
+        id: upload_logs
+        if: ${{ always() && steps.terragrunt.outputs.pipelines_logs_artifact_path != '' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: pipelines-logs-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.jobs.ChangeType }}-${{ steps.artifact_name.outputs.fragment }}
+          path: ${{ steps.terragrunt.outputs.pipelines_logs_artifact_path }}
+          if-no-files-found: warn
+          retention-days: 30
+          overwrite: true
+
       - name: Update comment
         if: always()
         uses: ./pipelines-actions/.github/actions/pipelines-comment-job-update
@@ -283,6 +304,7 @@ jobs:
           plan_apply_log_file_path: ${{ steps.terragrunt.outputs.plan_folder }}
           extended_log_file_path: ${{ steps.terragrunt.outputs.execute_stdout_log }}
           pipelines_report_file_path: ${{ steps.terragrunt.outputs.pipelines_report_file_path }}
+          logs_artifact_url: ${{ steps.upload_logs.outputs.artifact-url }}
           job_name: ${{ env.JOB_NAME }}
 
     outputs:


### PR DESCRIPTION
Implements plan for Linear issue [PF-173](https://linear.app/issue/69e4048d-9264-463e-a0f2-8ef0324bb797).

Plan source: https://github.com/gruntwork-io-team/linear-claude-plans/blob/main/plans/PF-173.md

---

<details>
<summary>Claude's implementation summary</summary>

```
No fixture impact. Implementation complete. Let me provide the summary of changes per repo.

---

## Summary of changes

### `gruntwork-io/pipelines` (this repo)

Added `EXPERIMENT_LOGS_AS_ARTIFACT` opt-in experiment and the CLI plumbing to surface a per-unit Terragrunt log artifact path and "Download Logs" link.

- `internal/features/features.go` — added `LogsAsArtifact` constant + default-OFF entry.
- `internal/features/features_test.go` — added focused test asserting default is false (the existing AST-driven `TestAllFeaturesHaveCase` also picks it up).
- `internal/actions/terragrunt/terragruntexecutor.go` — added `LogsArtifactPath string \`output:"logs_artifact_path,omitempty"\`` to `TerragruntOutput`; populated only when the experiment is enabled and `--combined-output-path` was provided. Added a `combinedOutputAbsPath()` helper shared with `writeCombinedOutput`.
- `internal/step/step.go` — added `LogsArtifactURL string \`json:"logs_artifact_url,omitempty"\`` to `StepSummary`.
- `internal/comment/comment.go` — added `LogsArtifactURL` to `CommentInfraChange` and copied it from `step.Result` in `formatCommentData`.
- `internal/comment/templates/comment.gohtml` — render a `· <a href=...>Download Logs</a>` anchor next to "View Job Logs" when `LogsArtifactURL` is non-empty.
- `internal/comment/comment_test.go` — added two tests covering present-link and absent-link cases.
- `internal/actions/statusupdate/statusupdate.go` — added `logsArtifactURL` field to `Update`, new param on `NewUpdate`, populated `StepSummary.LogsArtifactURL`.
- `main.go` — added `--logs-artifact-url` CLI flag on `status-update update`, threaded into `NewUpdate`.
- `internal/actions/gitlabyml/templates/execute.goyml` — extended the generated child-pipeline execute job's `artifacts:` stanza to include `access: developer`, `expire_in: 30 days`, and the `pipelines-artifacts/` directory.
- `internal/actions/gitlabyml/gitlabdynamicchildren_test.go` — updated the `TestExecutePlan` snapshot to match the new artifacts block.
- `test/plumbing/statusupdate/update/update_test.go` and `test/porcelain/add-units-consolidated/add-unit-consolidated_test.go` — added the new `logsArtifactURL` constructor arg (empty string) to existing `NewUpdate(...)` call sites.

### `gruntwork-io/pipelines-workflows`

Added a conditional artifact upload step in the matrix execute jobs and passed the resulting URL through to the comment-job-update step.

- `.github/workflows/pipelines.yml` — added `Sanitize artifact name fragment` shell step (replaces `/` with `-` in the working directory) and `Upload unit logs as artifact` using `actions/upload-artifact@v6.0.0`, both gated on `steps.terragrunt.outputs.pipelines_logs_artifact_path != ''`. Added `logs_artifact_url: ${{ steps.upload_logs.outputs.artifact-url }}` to the `Update comment` step.
- `.github/workflows/pipelines-root.yml` — same change, with the AccountsRequested/AccountsAdded skip condition propagated to the new steps.

### `gruntwork-io/pipelines-actions`

Declared the new step output on the execute action and accepted/forwarded the new URL on the comment-job-update action.

- `.github/actions/pipelines-execute/action.yml` — declared `pipelines_logs_artifact_path` in the top-level `outputs:` block so the CLI's `OutputWriter`-emitted value bubbles to the calling workflow.
- `.github/actions/pipelines-comment-job-update/action.yml` — added `logs_artifact_url` input (default empty) and plumbed it into the composite's `env:` as `LOGS_ARTIFACT_URL`.
- `.github/actions/pipelines-comment-job-update/scripts/update.sh` — defaulted `LOGS_ARTIFACT_URL` to empty and appended `--logs-artifact-url "$LOGS_ARTIFACT_URL"` to the `pipelines status-update update` invocation.

### `gruntwork-io/docs`

- `docs/2.0/reference/pipelines/feature-flags.md` — documented `PIPELINES_FEATURE_EXPERIMENT_LOGS_AS_ARTIFACT` between `IGNORE_UNITS_WITHOUT_ENVIRONMENT` and `MINIMIZE_BLAST_RADIUS`, including a note about workflow/action version requirements and the dual env-var / HCL `env { }` enablement options.

### Missing / out-of-scope repos

The plan calls for changes in two GitLab-side repositories that are **not** present in this checked-out workspace:

- `gitlab.com/gruntwork-io/pipelines-workflows` (referred to as `gitlab-pipelines-workflows`) — the plan said no template changes were required here; only the `pipelines` CLI change (already applied to `internal/actions/gitlabyml/templates/execute.goyml`) was needed. **Effectively done from this repo.**
- `gitlab.com/gruntwork-io/pipelines-actions` (referred to as `pipelines-gitlab-actions`) — the plan required edits to `scripts/pipelines-execute.sh` to: extract `LogsArtifactPath` from the CLI JSON via `jq`, conditionally stage the log to `./pipelines-artifacts/`, derive the GitLab raw-artifact URL from `CI_SERVER_URL`/`CI_PROJECT_PATH`/`CI_JOB_ID`, and forward it as `--logs-artifact-url` to `status-update update`. **This repo is not checked out — these changes are skipped here and must be applied in a follow-up PR against `pipelines-gitlab-actions`.**

Tests run: `go build ./...`, `go vet ./...`, and `go test ./internal/features/ ./internal/comment/ ./internal/actions/gitlabyml/ ./internal/platform/outputs/ ./internal/step/` all pass. Two preexisting test failures (`TestTerragruntPlanOutDirNestsByUnitPath` and `TestExecuteTerragrunt`) are environmental — they require the `terragrunt` binary on `$PATH` and are unrelated to these changes.
```

</details>

---

### Related PRs in this change set

- pipelines: https://github.com/gruntwork-io/pipelines/pull/637
- pipelines-actions: https://github.com/gruntwork-io/pipelines-actions/pull/167
- docs: https://github.com/gruntwork-io/docs/pull/3185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added downloadable logs to workflow runs, making Terragrunt unit logs easier to access after execution.
  * Updated run comments to include a direct link to the uploaded logs artifact.
  
* **Bug Fixes**
  * Improved artifact naming to avoid issues with path characters and make uploads more reliable.
  * Added safer handling when logs are unavailable, preventing workflow interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->