### PR TITLE
feat(pipelines): fill dynamic OTEL cicd/vcs resource attributes

### DIFF
--- a/.github/workflows/pipelines-drift-detection.yml
+++ b/.github/workflows/pipelines-drift-detection.yml
@@ -84,6 +84,13 @@ env:
   # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
   OTEL_SERVICE_NAME: Terragrunt
   OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  # New Relic OTLP caps payloads at 1MB (413 otherwise). Terragrunt's metric
+  # reader defaults to cumulative temporality, so each periodic export resends
+  # every metric stream of the run and outgrows the cap on large `run --all`
+  # stacks. Delta temporality keeps exports incremental; gzip is NR-recommended.
+  # https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/
+  OTEL_EXPORTER_OTLP_COMPRESSION: gzip
+  OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
   TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
   TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 

--- a/.github/workflows/pipelines-drift-detection.yml
+++ b/.github/workflows/pipelines-drift-detection.yml
@@ -64,6 +64,9 @@ on:
         required: false
       PR_CREATE_TOKEN:
         required: false
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
+
 env:
   PIPELINES_CLI_VERSION: ${{ inputs.pipelines_cli_version }}
   PIPELINES_ACTIONS_REPO: ${{ inputs.pipelines_actions_repo }}
@@ -72,6 +75,17 @@ env:
   PIPELINES_CREDENTIALS_REF: ${{ inputs.pipelines_credentials_ref }}
   BOILERPLATE_VERSION: v0.5.16
   GRUNTWORK_INSTALLER_VERSION: v0.0.40
+
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  # Terragrunt OpenTelemetry → New Relic OTLP ingest
+  # https://terragrunt.gruntwork.io/docs/troubleshooting/open-telemetry/
+  # OTEL_EXPORTER_OTLP_HEADERS is set per-job after loading the New Relic ingest
+  # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
+  OTEL_SERVICE_NAME: Terragrunt
+  OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
+  TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 
 jobs:
   determine_units:
@@ -226,6 +240,20 @@ jobs:
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
+
+      - name: Load Terragrunt OTEL credential
+        id: otel-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NEW_RELIC_OTEL_API_KEY: 'op://3hg5gdcz3m4epboxfdmltgmo2u/d2gdylswmgmrfoognkxidbd7ja/credential' # op://CI/"Terragrunt OpenTelemetry" New Relic API Key
+
+      - name: Set OTEL_EXPORTER_OTLP_HEADERS
+        env:
+          NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
+        run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Determine Drift
         id: determine-drift

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -70,6 +70,8 @@ on:
         required: false
       PIPELINES_PLAN_ENCRYPTION_KEY:
         required: false
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
 
 env:
   PIPELINES_CLI_VERSION: ${{ inputs.pipelines_cli_version }}
@@ -83,6 +85,8 @@ env:
   BOILERPLATE_VERSION: v0.5.16
   GRUNTWORK_INSTALLER_VERSION: v0.0.40
 
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
   # Disables all executions of terragrunt. This is useful for debugging
   # specifics of pipelines actions/workflows and bypassing the (usually time consuming)
   # actual IaC execution.
@@ -91,6 +95,15 @@ env:
   # GitHub Actions tends to hit resource exhaustion and kill running jobs
   # if we leave parallelism unbounded, so we set the max to 10 for a sane default.
   TG_PARALLELISM: 10
+
+  # Terragrunt OpenTelemetry → New Relic OTLP ingest
+  # https://terragrunt.gruntwork.io/docs/troubleshooting/open-telemetry/
+  # OTEL_EXPORTER_OTLP_HEADERS is set per-job after loading the New Relic ingest
+  # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
+  OTEL_SERVICE_NAME: Terragrunt
+  OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
+  TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 
 jobs:
   pipelines_orchestrate:
@@ -292,6 +305,20 @@ jobs:
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
+
+      - name: Load Terragrunt OTEL credential
+        id: otel-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NEW_RELIC_OTEL_API_KEY: 'op://3hg5gdcz3m4epboxfdmltgmo2u/d2gdylswmgmrfoognkxidbd7ja/credential' # op://CI/"Terragrunt OpenTelemetry" New Relic API Key
+
+      - name: Set OTEL_EXPORTER_OTLP_HEADERS
+        env:
+          NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
+        run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Set up custom actions path
         if: ${{ !inputs.pipelines_actions_customizations_repo }}
@@ -497,6 +524,20 @@ jobs:
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
+
+      - name: Load Terragrunt OTEL credential
+        id: otel-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NEW_RELIC_OTEL_API_KEY: 'op://3hg5gdcz3m4epboxfdmltgmo2u/d2gdylswmgmrfoognkxidbd7ja/credential' # op://CI/"Terragrunt OpenTelemetry" New Relic API Key
+
+      - name: Set OTEL_EXPORTER_OTLP_HEADERS
+        env:
+          NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
+        run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Set up custom actions path
         if: ${{ !inputs.pipelines_actions_customizations_repo }}

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -102,6 +102,13 @@ env:
   # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
   OTEL_SERVICE_NAME: Terragrunt
   OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  # New Relic OTLP caps payloads at 1MB (413 otherwise). Terragrunt's metric
+  # reader defaults to cumulative temporality, so each periodic export resends
+  # every metric stream of the run and outgrows the cap on large `run --all`
+  # stacks. Delta temporality keeps exports incremental; gzip is NR-recommended.
+  # https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/
+  OTEL_EXPORTER_OTLP_COMPRESSION: gzip
+  OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
   TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
   TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 

--- a/.github/workflows/pipelines-unlock.yml
+++ b/.github/workflows/pipelines-unlock.yml
@@ -73,12 +73,26 @@ on:
         required: false
       PIPELINES_CUSTOMER_ORG_READ_TOKEN:
         required: false
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
+
 env:
   PIPELINES_CLI_VERSION: ${{ inputs.pipelines_cli_version }}
   PIPELINES_ACTIONS_REPO: ${{ inputs.pipelines_actions_repo }}
   PIPELINES_ACTIONS_REF: ${{ inputs.pipelines_actions_ref }}
   PIPELINES_CREDENTIALS_REPO: ${{ inputs.pipelines_credentials_repo }}
   PIPELINES_CREDENTIALS_REF: ${{ inputs.pipelines_credentials_ref }}
+
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  # Terragrunt OpenTelemetry → New Relic OTLP ingest
+  # https://terragrunt.gruntwork.io/docs/troubleshooting/open-telemetry/
+  # OTEL_EXPORTER_OTLP_HEADERS is set per-job after loading the New Relic ingest
+  # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
+  OTEL_SERVICE_NAME: Terragrunt
+  OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
+  TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 
 jobs:
   unlock_one:
@@ -158,6 +172,20 @@ jobs:
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
+
+      - name: Load Terragrunt OTEL credential
+        id: otel-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NEW_RELIC_OTEL_API_KEY: 'op://3hg5gdcz3m4epboxfdmltgmo2u/d2gdylswmgmrfoognkxidbd7ja/credential' # op://CI/"Terragrunt OpenTelemetry" New Relic API Key
+
+      - name: Set OTEL_EXPORTER_OTLP_HEADERS
+        env:
+          NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
+        run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Pipelines Unlock Unit
         shell: bash
@@ -252,6 +280,20 @@ jobs:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
 
+      - name: Load Terragrunt OTEL credential
+        id: otel-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NEW_RELIC_OTEL_API_KEY: 'op://3hg5gdcz3m4epboxfdmltgmo2u/d2gdylswmgmrfoognkxidbd7ja/credential' # op://CI/"Terragrunt OpenTelemetry" New Relic API Key
+
+      - name: Set OTEL_EXPORTER_OTLP_HEADERS
+        env:
+          NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
+        run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
+
       - name: Unlock All
         id: unlock_tables
         shell: bash
@@ -344,6 +386,20 @@ jobs:
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
+
+      - name: Load Terragrunt OTEL credential
+        id: otel-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NEW_RELIC_OTEL_API_KEY: 'op://3hg5gdcz3m4epboxfdmltgmo2u/d2gdylswmgmrfoognkxidbd7ja/credential' # op://CI/"Terragrunt OpenTelemetry" New Relic API Key
+
+      - name: Set OTEL_EXPORTER_OTLP_HEADERS
+        env:
+          NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
+        run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Pipelines Reinit Unit
         shell: bash

--- a/.github/workflows/pipelines-unlock.yml
+++ b/.github/workflows/pipelines-unlock.yml
@@ -91,6 +91,13 @@ env:
   # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
   OTEL_SERVICE_NAME: Terragrunt
   OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  # New Relic OTLP caps payloads at 1MB (413 otherwise). Terragrunt's metric
+  # reader defaults to cumulative temporality, so each periodic export resends
+  # every metric stream of the run and outgrows the cap on large `run --all`
+  # stacks. Delta temporality keeps exports incremental; gzip is NR-recommended.
+  # https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/
+  OTEL_EXPORTER_OTLP_COMPRESSION: gzip
+  OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
   TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
   TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -74,12 +74,22 @@ env:
   PIPELINES_ACTIONS_REF: ${{ inputs.pipelines_actions_ref }}
   PIPELINES_CREDENTIALS_REPO: ${{ inputs.pipelines_credentials_repo }}
   PIPELINES_CREDENTIALS_REF: ${{ inputs.pipelines_credentials_ref }}
+
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
   NAMESPACE: ${{ inputs.namespace }}
 
   # GitHub Actions tends to hit resource exhaustion and kill running jobs
   # if we leave parallelism unbounded, so we set the max to 10 for a sane default.
   TG_PARALLELISM: 10
+
+  # Terragrunt OpenTelemetry → New Relic OTLP ingest
+  # https://terragrunt.gruntwork.io/docs/troubleshooting/open-telemetry/
+  # OTEL_EXPORTER_OTLP_HEADERS is set per-job after loading the New Relic ingest
+  # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
+  OTEL_SERVICE_NAME: Terragrunt
+  OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
+  TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 
 jobs:
   pipelines_orchestrate:
@@ -270,6 +280,19 @@ jobs:
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NEW_RELIC_OTEL_API_KEY: 'op://3hg5gdcz3m4epboxfdmltgmo2u/d2gdylswmgmrfoognkxidbd7ja/credential' # op://CI/"Terragrunt OpenTelemetry" New Relic API Key
+
+      - name: Set OTEL_EXPORTER_OTLP_HEADERS
+        env:
+          NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
+        run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
 
       - name: "[TerragruntExecute]: Run terragrunt ${{ matrix.jobs.Action.Command }} in ${{ matrix.jobs.WorkingDirectory }}"
         id: terragrunt

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -88,6 +88,13 @@ env:
   # key from 1Password (see "Load Terragrunt OTEL credential" steps below).
   OTEL_SERVICE_NAME: Terragrunt
   OTEL_EXPORTER_OTLP_ENDPOINT: https://otlp.nr-data.net
+  # New Relic OTLP caps payloads at 1MB (413 otherwise). Terragrunt's metric
+  # reader defaults to cumulative temporality, so each periodic export resends
+  # every metric stream of the run and outgrows the cap on large `run --all`
+  # stacks. Delta temporality keeps exports incremental; gzip is NR-recommended.
+  # https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/
+  OTEL_EXPORTER_OTLP_COMPRESSION: gzip
+  OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
   TG_TELEMETRY_METRIC_EXPORTER: otlpHttp
   TG_TELEMETRY_TRACE_EXPORTER: otlpHttp
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -340,6 +340,13 @@ jobs:
         uses: ./pipelines-actions/.github/actions/pipelines-execute
         env:
           CHANGE_TYPE: ${{ matrix.jobs.ChangeType }}
+          # Dynamic OTEL resource attributes that need GitHub Actions context
+          # (run id, worker, VCS ref) which .gruntwork/repository.hcl cannot
+          # interpolate. Set at step scope so `runner.*` resolves. Derived from
+          # github.* so every GWP infra-live repo gets correct per-repo values —
+          # do NOT hardcode repo names here (this workflow is shared).
+          # https://opentelemetry.io/docs/specs/semconv/resource/cicd/
+          OTEL_RESOURCE_ATTRIBUTES: "cicd.pipeline.name=gruntwork-pipelines,cicd.pipeline.run.id=${{ github.run_id }},cicd.pipeline.run.url.full=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }},cicd.worker.id=${{ runner.name }},cicd.worker.name=${{ runner.name }},vcs.repository.url.full=${{ github.server_url }}/${{ github.repository }},vcs.repository.name=${{ github.event.repository.name }},vcs.ref.head.name=${{ github.head_ref || github.ref_name }},vcs.ref.head.revision=${{ github.sha }}"
         with:
           PIPELINES_GRUNTWORK_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).gruntwork_read }}
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -211,6 +211,11 @@ jobs:
   pipelines_execute:
     env:
       JOB_NAME: ${{ contains(matrix.jobs.Action.Command, 'plan') && 'Plan' || 'Apply' }} - ${{ matrix.jobs.ChangeType }} - ${{ matrix.jobs.WorkingDirectory }}
+      # Pin the Terragrunt Provider Cache Server store to a deterministic path so
+      # the `Cache Terraform providers` step below caches the same location. The
+      # server itself is enabled via TG_PROVIDER_CACHE in `.gruntwork/repository.hcl`.
+      # https://terragrunt.gruntwork.io/docs/features/provider-cache-server/
+      TG_PROVIDER_CACHE_DIR: ${{ github.workspace }}/.tg-cache/providers
     name: ${{ contains(matrix.jobs.Action.Command, 'plan') && 'Plan' || 'Apply' }} - ${{ matrix.jobs.ChangeType }} - ${{ matrix.jobs.WorkingDirectory }}
     needs: [pipelines_orchestrate]
     runs-on: ${{ fromJSON(inputs.runner) }}
@@ -301,6 +306,34 @@ jobs:
         env:
           NEW_RELIC_OTEL_API_KEY: ${{ steps.otel-secrets.outputs.NEW_RELIC_OTEL_API_KEY }}
         run: echo "OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_OTEL_API_KEY}" >> "$GITHUB_ENV"
+
+      # Persist the Terragrunt Provider Cache Server store across runs. Each unit
+      # runs as its own matrix job on a clean runner, so without this every job
+      # re-downloads its providers from the registry. Keyed off the committed
+      # `.terraform.lock.hcl` files; `restore-keys` gives a warm partial hit on a
+      # provider-version bump. https://terragrunt.gruntwork.io/docs/features/provider-cache-server/
+      - name: Cache Terraform providers
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: ${{ github.workspace }}/.tg-cache/providers
+          key: tg-providers-${{ hashFiles('infra-live-repo/**/.terraform.lock.hcl') }}
+          restore-keys: |
+            tg-providers-
+
+      # Persist the Terragrunt Content Addressable Store (CAS) across runs to
+      # avoid re-fetching module sources (e.g. livelink/terraform). CAS has no
+      # path override, so cache its default location. Rolling key: a per-commit
+      # key always misses, so `restore-keys` warm-restores the newest store and
+      # the run appends only genuinely-new sources (CAS is content-addressed, so
+      # no precise key is needed). Superseded snapshots age out via GitHub cache
+      # eviction (7-day-untouched + 10 GB LRU). https://terragrunt.gruntwork.io/docs/features/cas/
+      - name: Cache Terragrunt CAS (module sources)
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: ~/.cache/terragrunt/cas
+          key: tg-cas-${{ github.sha }}
+          restore-keys: |
+            tg-cas-
 
       - name: "[TerragruntExecute]: Run terragrunt ${{ matrix.jobs.Action.Command }} in ${{ matrix.jobs.WorkingDirectory }}"
         id: terragrunt

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -60,6 +60,8 @@ on:
         required: false
       PIPELINES_PLAN_ENCRYPTION_KEY:
         required: false
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
 
 env:
   PIPELINES_CLI_VERSION: ${{ inputs.pipelines_cli_version }}
@@ -67,6 +69,7 @@ env:
   PIPELINES_ACTIONS_REF: ${{ inputs.pipelines_actions_ref }}
   PIPELINES_CREDENTIALS_REPO: ${{ inputs.pipelines_credentials_repo }}
   PIPELINES_CREDENTIALS_REF: ${{ inputs.pipelines_credentials_ref }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   # GitHub Actions tends to hit resource exhaustion and kill running jobs
   # if we leave parallelism unbounded, so we set the max to 10 for a sane default.

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -282,6 +282,7 @@ jobs:
           PIPELINES_CUSTOMER_ORG_READ_TOKEN: ${{ fromJson(steps.pipelines-tokens.outputs.tokens_json).customer_org_read }}
 
       - name: Load secrets from 1Password
+        id: otel-secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           export-env: false

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -48,6 +48,11 @@ on:
         type: string
         default: "v2.0.0"
         description: "For Gruntwork internal testing - the ref of the pipelines credentials to use"
+      namespace:
+        type: string
+        required: false
+        default: ""
+        description: "Namespace"
 
     secrets:
       PIPELINES_READ_TOKEN:
@@ -70,6 +75,7 @@ env:
   PIPELINES_CREDENTIALS_REPO: ${{ inputs.pipelines_credentials_repo }}
   PIPELINES_CREDENTIALS_REF: ${{ inputs.pipelines_credentials_ref }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  NAMESPACE: ${{ inputs.namespace }}
 
   # GitHub Actions tends to hit resource exhaustion and kill running jobs
   # if we leave parallelism unbounded, so we set the max to 10 for a sane default.

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -88,6 +88,11 @@ jobs:
     env:
       JOB_NAME: "Detect Infrastructure Changes"
     steps:
+      # NOTE: It may help to highlight 1Password IP level rate-limiting issues
+      - name: Get GHA runner public IP
+        continue-on-error: true
+        run: curl -s https://api.ipify.org
+
       - name: Record workflow env vars
         env:
           PIPELINES_BINARY_URL: ${{ inputs.pipelines_binary_url }}


### PR DESCRIPTION
## What

Set `OTEL_RESOURCE_ATTRIBUTES` at the `[TerragruntExecute]` step so GWP Terragrunt traces carry the full CI/CD + VCS attribute set, filled from GitHub Actions context.

## Why

Consuming repos set `OTEL_RESOURCE_ATTRIBUTES` in `.gruntwork/repository.hcl`, which is **static** — it cannot interpolate `github.*`/`runner.*`. So GWP traces only ever carried `cicd.pipeline.name` + `vcs.repository.*`; `cicd.pipeline.run.id`, `cicd.worker.*`, and `vcs.ref.*` were absent (only the Plumber composite action filled them).

Verified against New Relic (account `183613`, `service.name = 'Terragrunt'`, `cicd.pipeline.name = 'gruntwork-pipelines'`) — those keys do not exist on GWP spans today (`keyset()` confirms absence, not null values).

## How

* Step-scope `env:` on `[TerragruntExecute]` (alongside `CHANGE_TYPE`) — `runner.*` resolves at step scope, and the value reaches the terragrunt subprocess via the same env-flow the existing `OTEL_EXPORTER_OTLP_HEADERS` step already relies on.
* Values derived from `github.*` (not hardcoded) so **every** GWP infra-live repo gets correct per-repo attribution. Not copying Plumber's hardcoded `vcs.repository.name=dice-environments`, which would poison other repos' traces on this shared workflow.

## Blast radius

This workflow is shared (`@main`, moving ref). On merge it applies to all consuming repos immediately. Any repo still setting `OTEL_RESOURCE_ATTRIBUTES` in its own `repository.hcl` will double-set the var — remove it there (dice-environments done in the paired PR below).

## Paired change

`OTEL_RESOURCE_ATTRIBUTES` removed from dice-environments `.gruntwork/repository.hcl`: livelink/dice-environments#DICE_PR

## Verify after merge

Trigger one GWP apply, then:

```
newrelic nrql query -a 183613 -q "SELECT cicd.pipeline.run.id, cicd.worker.id, vcs.ref.head.revision FROM Span WHERE service.name = 'Terragrunt' AND cicd.pipeline.name = 'gruntwork-pipelines' SINCE 10 minutes ago LIMIT 1"
```

Expect non-null on all three (absent today).

## Reference

* [OTel semconv – CI/CD resource attributes](https://opentelemetry.io/docs/specs/semconv/resource/cicd/)
* [Terragrunt OpenTelemetry](https://terragrunt.gruntwork.io/docs/troubleshooting/open-telemetry/)
