### PR TITLE
Bump mise to 2026.8.2 for a current attestation trust root

### DIFF
--- a/.github/workflows/pipelines-drift-detection.yml
+++ b/.github/workflows/pipelines-drift-detection.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Install Pipelines CLI
@@ -212,7 +212,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Install Pipelines CLI

--- a/.github/workflows/pipelines-root.yml
+++ b/.github/workflows/pipelines-root.yml
@@ -290,7 +290,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth
@@ -495,7 +495,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth
@@ -746,7 +746,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth

--- a/.github/workflows/pipelines-unlock.yml
+++ b/.github/workflows/pipelines-unlock.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Test Terraform, OpenTofu and Terragrunt
@@ -229,7 +229,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Test Terraform, OpenTofu and Terragrunt
@@ -324,7 +324,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
       - name: Test Terraform, OpenTofu and Terragrunt
         shell: bash

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -254,7 +254,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth
@@ -362,7 +362,7 @@ jobs:
         with:
           install: true
           cache: true
-          version: 2026.4.11
+          version: 2026.8.2
           working_directory: "./infra-live-repo"
 
       - name: Configure code auth


### PR DESCRIPTION
mise 2026.4.11 predates GitHub's current TSA certificate, so its bundled Sigstore trust root cannot verify recently attested release artifacts and github-backend tool installs fail with a timestamp verification error. Trust roots accumulate certificates, so the newer mise still verifies older artifacts. Needed for DEV-1578 (pinning the infracost v2 CLI, whose recent releases are attested with the new certificate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Mise version used by automated pipeline workflows.
  * Applied the update across pipeline execution, drift detection, baseline, status-check, unlock, and reinitialization jobs.
  * Improved consistency and reliability of workflow tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->